### PR TITLE
Removed multiprocessingi in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ astropy
 astroquery
 matplotlib
 mpdaf
-multiprocessing
 numpy
 prettytable
 PyPDF2


### PR DESCRIPTION
Installation of sharpener with pip fails because of multiprocessing module in requirements.txt. Multiprocessing does not have to be part of requirements.txt for Python2.7 and Python3 as it is an internal module.  Therefore, I removed Multiprocessing module from list of requirements.